### PR TITLE
Increase results per page to 5000

### DIFF
--- a/lib/agilecrm-wrapper/contact.rb
+++ b/lib/agilecrm-wrapper/contact.rb
@@ -8,7 +8,7 @@ module AgileCRMWrapper
 
     class << self
       def all
-        response = AgileCRMWrapper.connection.get('contacts')
+        response = AgileCRMWrapper.connection.get('contacts?page_size=5000')
         if response.status == 200
           return response.body.map { |body| new body }
         else


### PR DESCRIPTION
Currently, calling `Contacts.all` returns 50 items (as far as I can tell). This change returns all results.

**Caution**: this can result in very long request times.

TODO: Replace this with option to paginate through results for `all` command, rather than hard-coding a number of results (i.e. If you have 6,000 records the `all` option would only get 5/6 of them).
